### PR TITLE
display, layout, and crash fixes

### DIFF
--- a/app/src/main/java/com/example/hw5_yelpclone/MainActivity.kt
+++ b/app/src/main/java/com/example/hw5_yelpclone/MainActivity.kt
@@ -52,6 +52,7 @@ class MainActivity : AppCompatActivity() {
         if (food.isEmpty() || location.isEmpty()){
             showDialog2(view)
         }else{
+            restaurant.clear();
             yelpService.searchRestaurants("Bearer $API_KEY",food, location).enqueue(object : Callback<YelpSearchResult> {
                 override fun onResponse(call: Call<YelpSearchResult>, response: Response<YelpSearchResult>) {
                     Log.i(TAG, "onResponse $response")

--- a/app/src/main/java/com/example/hw5_yelpclone/RestaurantsAdapter.kt
+++ b/app/src/main/java/com/example/hw5_yelpclone/RestaurantsAdapter.kt
@@ -1,6 +1,7 @@
 package com.example.hw5_yelpclone
 
 import android.content.Context
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -14,6 +15,7 @@ import kotlinx.android.synthetic.main.item_restaurant.view.*
 
 class RestaurantsAdapter(val context: Context, val restaurant: List<YelpRestaurant>) : RecyclerView.Adapter<RestaurantsAdapter.ViewHolder>(){
 
+    private val TAG = "adapter"
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         return ViewHolder(LayoutInflater.from(context).inflate(R.layout.item_restaurant, parent, false))
     }
@@ -34,7 +36,13 @@ class RestaurantsAdapter(val context: Context, val restaurant: List<YelpRestaura
             itemView.category.text = restaurants.categories[0].title
             itemView.distance.text = restaurants.displayDistance()
             itemView.price.text = restaurants.price
-            Picasso.get().load(restaurants.imageUrl).into(itemView.imageView2)
+
+            if (restaurants.imageUrl ==null || restaurants.imageUrl.isEmpty()){
+                Picasso.get().load("https://sciences.ucf.edu/psychology/wp-content/uploads/sites/63/2019/09/No-Image-Available.png").into(itemView.imageView2)
+            }
+            else {
+                Picasso.get().load(restaurants.imageUrl).into(itemView.imageView2)
+            }
         }
 
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -14,7 +14,8 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/searchLocation" />
+        app:layout_constraintTop_toBottomOf="@+id/searchLocation"
+        tools:listitem="@layout/item_restaurant" />
 
     <EditText
         android:id="@+id/searchFood"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,9 +8,8 @@
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/restaurantRecyler"
-        android:layout_width="410dp"
-        android:layout_height="727dp"
-        android:layout_marginTop="8dp"
+        android:layout_width="403dp"
+        android:layout_height="536dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/item_restaurant.xml
+++ b/app/src/main/res/layout/item_restaurant.xml
@@ -8,12 +8,12 @@
 
     <TextView
         android:id="@+id/price"
-        android:layout_width="46dp"
-        android:layout_height="17dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
         android:text="TextView"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.991"
+        app:layout_constraintHorizontal_bias="0.954"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/distance"
         tools:text="$$" />
@@ -35,9 +35,11 @@
 
     <ImageView
         android:id="@+id/imageView2"
-        android:layout_width="158dp"
-        android:layout_height="158dp"
+        android:layout_width="125dp"
+        android:layout_height="125dp"
+        android:layout_margin="10px"
         android:scaleType="centerCrop"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
@@ -60,10 +62,10 @@
         android:id="@+id/address"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="84dp"
+        android:layout_marginTop="80dp"
         android:text="TextView"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.153"
+        app:layout_constraintHorizontal_bias="0.048"
         app:layout_constraintStart_toEndOf="@+id/imageView2"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="CCSU" />
@@ -72,23 +74,24 @@
         android:id="@+id/category"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="132dp"
+        android:layout_marginTop="104dp"
         android:text="TextView"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.151"
+        app:layout_constraintHorizontal_bias="0.048"
         app:layout_constraintStart_toEndOf="@+id/imageView2"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Pizza" />
 
     <TextView
         android:id="@+id/distance"
-        android:layout_width="49dp"
-        android:layout_height="23dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_marginTop="44dp"
+        android:layout_marginRight="8dp"
         android:text="TextView"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.971"
-        app:layout_constraintStart_toEndOf="@+id/restaurantName"
+        app:layout_constraintHorizontal_bias="0.888"
+        app:layout_constraintStart_toEndOf="@+id/numReviews"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="2.0 mi" />
 


### PR DESCRIPTION
-Fixed display by clearing recycler view before each new search
-small restructure changes to individual list item textviews to prevent text from running off the screen
-fixed layout to not cut off the last item in recycler view
-fixed crashing occasional crashing problem when a business did not have image to display, now a place holder image is displayed instead